### PR TITLE
Fix GDecomp#redecorate

### DIFF
--- a/core/src/main/scala/Decomp.scala
+++ b/core/src/main/scala/Decomp.scala
@@ -67,7 +67,7 @@ case class GDecomp[N,A,B](ctx: Context[N,A,B], rest: Graph[N,A,B]) {
    */
   def redecorate[C](f: GDecomp[N,A,B] => C): GDecomp[N,C,B] =
     GDecomp(ctx.copy(label = f(this)),
-            rest.gmap { c => c.copy(label = f(rest.decomp(c.vertex).toGDecomp.get)) })
+            rest.gmap { c => c.copy(label = f(toGraph.decomp(c.vertex).toGDecomp.get)) })
 
   /**
    * Decompose the graph on the nodes returned by `f`.

--- a/core/src/test/scala/GraphGen.scala
+++ b/core/src/test/scala/GraphGen.scala
@@ -52,7 +52,8 @@ object GraphGen {
 
   def genGDecomp[N: Arbitrary, A: Arbitrary, B: Arbitrary]: Gen[GDecomp[N,A,B]] = for {
     ctx <- arbitrary[Context[N,A,B]]
-    g <- arbitrary[Graph[N,A,B]]
+    // The remainder of the graph should not reference the focus of the decomposition or its incident edges
+    g <- arbitrary[Graph[N,A,B]].map(_.removeNode(ctx.vertex))
   } yield GDecomp(ctx, g)
 
   implicit def arbitraryGDecomp[A: Arbitrary, B: Arbitrary, N: Arbitrary]: Arbitrary[GDecomp[N, A, B]] = Arbitrary(genGDecomp[N,A,B])


### PR DESCRIPTION
- Redecoration includes the focus of the decomposition when acting on
the rest of the graph
- Fix GDecomp generator so incorrect instances cannot be built (this
should probably be a smart constructor)

/cc @runarorama 