### PR TITLE
cats-1.0.1

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,4 +1,4 @@
-val CatsVersion = "1.0.0"
+val CatsVersion = "1.0.1"
 
 libraryDependencies ++= Seq(
   "org.typelevel"              %% "cats-free"                 % CatsVersion,


### PR DESCRIPTION
Works around irritating Maven ordering of 1.0.0-MF. 
https://github.com/typelevel/cats/issues/2131