### PR TITLE
Brings back commented tree ops

### DIFF
--- a/core/src/main/scala/Graph.scala
+++ b/core/src/main/scala/Graph.scala
@@ -663,7 +663,6 @@ case class Graph[N,A,B](rep: GraphRep[N,A,B]) {
    */
   def rdfs(vs: Seq[N]): Seq[N] = xdfsWith(vs, _.predecessors, _.vertex)
 
-  /*
   /**
    * Finds the transitive closure of this graph.
    * @group dfs
@@ -680,7 +679,7 @@ case class Graph[N,A,B](rep: GraphRep[N,A,B]) {
    * Finds all the reachable nodes from a given node, using DFS
    * @group dfs
    */
-  def reachable(v: N): Vector[N] = dff(Seq(v)).flatMap(_.flatten)
+  def reachable(v: N): Vector[N] = dff(Seq(v)).flatMap(flattenTree)
 
   /**
    * Depth-first forest. Follows successors of the given nodes. The result is
@@ -720,11 +719,10 @@ case class Graph[N,A,B](rep: GraphRep[N,A,B]) {
     else decomp(vs.head) match {
       case Decomp(None, g) => g.xdfWith(vs.tail, d, f)
       case Decomp(Some(c), g) =>
-        val (xs, g2) = g.xdfWith(d(c), d, f)
+        val (xs, _) = g.xdfWith(d(c), d, f)
         val (ys, g3) = g.xdfWith(vs.tail, d, f)
-        (Cofree[Stream, C](f(c), Eval.later(xs.toStream)) +: ys, g3)
+        (Node(f(c), xs.toStream) +: ys, g3)
     }
-   */
 
   import scala.collection.immutable.Queue
 

--- a/core/src/main/scala/Node.scala
+++ b/core/src/main/scala/Node.scala
@@ -1,0 +1,28 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2018 Verizon.  All Rights Reserved.
+//:
+//:   Licensed under the Apache License, Version 2.0 (the "License");
+//:   you may not use this file except in compliance with the License.
+//:   You may obtain a copy of the License at
+//:
+//:       http://www.apache.org/licenses/LICENSE-2.0
+//:
+//:   Unless required by applicable law or agreed to in writing, software
+//:   distributed under the License is distributed on an "AS IS" BASIS,
+//:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//:   See the License for the specific language governing permissions and
+//:   limitations under the License.
+//:
+//: ----------------------------------------------------------------------------
+
+package quiver
+
+import cats.Eval
+import cats.free.Cofree
+
+object Node {
+  def apply[A](root: A, forest: => Stream[Tree[A]]): Tree[A] =
+    Cofree[Stream, A](root, Eval.later(forest))
+
+  def unapply[A](t: Tree[A]): Option[(A, Stream[Tree[A]])] = Some((t.head, t.tail.value))
+}

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -16,6 +16,7 @@
 //: ----------------------------------------------------------------------------
 
 import cats.{Monoid, Order}
+import cats.free.Cofree
 import cats.implicits._
 
 /**
@@ -275,5 +276,14 @@ package object quiver {
 
     def mapKeys[A1](f: A => A1): Map[A1, B] =
       self.map { case (k, v) => f(k) -> v }
+  }
+
+
+  type Tree[A] = Cofree[Stream, A]
+
+  def flattenTree[A](tree: Tree[A]): Stream[A] = {
+    def go(tree: Tree[A], xs: Stream[A]): Stream[A] =
+      Stream.cons(tree.head, tree.tail.value.foldRight(xs)(go(_, _)))
+    go(tree, Stream.Empty)
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "7.0.0-SNAPSHOT"
+version in ThisBuild := "7.1.0-SNAPSHOT"


### PR DESCRIPTION
None of these operations had unit tests, and were commented in the port to Cats because they used `scalaz.Free`.  This brings them back, backed by an alias to `Cofree[Stream, A]`.  The most obvious difference is that the root label of a `Tree` is lazy, but the head of a `Cofree` is not.  Unsure whether that will eat us.

It would be far better if we had unit tests for these, but I don't know all the use cases.  If someone can supply those, I could be shamed into adding tests.

An alternate approach would be to port `scalaz.Tree` to cats inside this project.
